### PR TITLE
docs: display CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 Utils for java
 
 ## CI
-[//]: # ([![Build]&#40;https://github.com/fabiitch/Nz/workflows/Build%20Gradle/badge.svg&#41;]&#40;https://github.com/fabiitch/Nz/actions/workflows/build.yml&#41;)
+[![CI](https://github.com/fabiitch/Nz/actions/workflows/ci.yml/badge.svg)](https://github.com/fabiitch/Nz/actions/workflows/ci.yml)
 


### PR DESCRIPTION
## Summary
- show CI workflow badge in README

## Testing
- `./gradlew test` *(fails: Unable to download toolchain, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a79f2690832182dc1c53a664d8a5